### PR TITLE
Pow invitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,12 @@ config :my_app, :pow_assent,
 
 The e-mail fetched from the provider is assumed already confirmed, and the user will have `:email_confirmed_at` set when inserted. If a user enters an e-mail then the user will have to confirm their e-mail before they can sign in.
 
+### PowInvitation
+
+PowAssent works out of the box with PowInvitation. If a user identity is created, the an invited user will have the `:invitation_accepted_at` set.
+
+Provider links will have an `invitation_token` query param if an invited user exists in the connection. This will be used in the authorization callback flow to load the invited user.
+
 ## Security concerns
 
 All sessions created through PowAssent provider authentication are temporary. However, it's a good idea to do some housekeeping in your app and make sure that you have the level of security as warranted by the scope of your app. That may include requiring users to re-authenticate before viewing or editing their user details.

--- a/config/test.exs
+++ b/config/test.exs
@@ -13,7 +13,11 @@ config :pow_assent, PowAssent.Test.EmailConfirmation.Phoenix.Endpoint,
   secret_key_base: String.duplicate("abcdefghijklmnopqrstuvxyz0123456789", 2),
   render_errors: [view: PowAssent.Test.Phoenix.ErrorView, accepts: ~w(html json)]
 
-  config :pow_assent, PowAssent.Test.NoRegistration.Phoenix.Endpoint,
+  config :pow_assent, PowAssent.Test.Invitation.Phoenix.Endpoint,
+  secret_key_base: String.duplicate("abcdefghijklmnopqrstuvxyz0123456789", 2),
+  render_errors: [view: PowAssent.Test.Phoenix.ErrorView, accepts: ~w(html json)]
+
+config :pow_assent, PowAssent.Test.NoRegistration.Phoenix.Endpoint,
   secret_key_base: String.duplicate("abcdefghijklmnopqrstuvxyz0123456789", 2),
   render_errors: [view: PowAssent.Test.Phoenix.ErrorView, accepts: ~w(html json)]
 

--- a/lib/pow_assent/ecto/schema.ex
+++ b/lib/pow_assent/ecto/schema.ex
@@ -88,10 +88,18 @@ defmodule PowAssent.Ecto.Schema do
   def changeset(user_or_changeset, user_identity, attrs, user_id_attrs, _config) do
     user_or_changeset
     |> Changeset.change()
+    |> maybe_accept_invitation()
     |> user_id_field_changeset(attrs, user_id_attrs)
     |> Changeset.cast(%{user_identities: [user_identity]}, [])
     |> Changeset.cast_assoc(:user_identities)
   end
+
+  defp maybe_accept_invitation(%Changeset{data: %user_mod{invitation_token: token, invitation_accepted_at: nil} = changeset}) when not is_nil(token) do
+    accepted_at = Pow.Ecto.Schema.__timestamp_for__(user_mod, :invitation_accepted_at)
+
+    Changeset.change(changeset, invitation_accepted_at: accepted_at)
+  end
+  defp maybe_accept_invitation(changeset), do: changeset
 
   defp user_id_field_changeset(changeset, attrs, nil) do
     changeset

--- a/lib/pow_assent/phoenix/views/view_helpers.ex
+++ b/lib/pow_assent/phoenix/views/view_helpers.ex
@@ -33,9 +33,14 @@ defmodule PowAssent.Phoenix.ViewHelpers do
     end
   end
 
-  defp oauth_signin_link(conn, provider) do
+  defp oauth_signin_link(%{assigns: %{invited_user: %{invitation_token: token}}} = conn, provider) when not is_nil(token) do
+    do_oauth_signin_link(conn, provider, invitation_token: token)
+  end
+  defp oauth_signin_link(conn, provider), do: do_oauth_signin_link(conn, provider)
+
+  defp do_oauth_signin_link(conn, provider, query_params \\[]) do
     msg  = AuthorizationController.messages(conn).login_with_provider(%{conn | params: %{"provider" => provider}})
-    path = AuthorizationController.routes(conn).path_for(conn, AuthorizationController, :new, [provider])
+    path = AuthorizationController.routes(conn).path_for(conn, AuthorizationController, :new, [provider], query_params)
 
     Link.link(msg, to: path)
   end

--- a/test/pow_assent/ecto/schema_test.exs
+++ b/test/pow_assent/ecto/schema_test.exs
@@ -17,6 +17,7 @@ defmodule PowAssent.Ecto.SchemaTest do
 
   alias PowAssent.Test.Ecto.{Repo, Users.User}
   alias PowAssent.Test.EmailConfirmation.Users.User, as: UserConfirmEmail
+  alias PowAssent.Test.Invitation.Users.User, as: InvitationUser
 
   test "user_schema/1" do
     user = %User{}
@@ -64,6 +65,17 @@ defmodule PowAssent.Ecto.SchemaTest do
 
       changeset = User.user_identity_changeset(%User{}, @user_identity, %{email: "test@example.com"}, nil)
       refute changeset.changes[:email_confirmed_at]
+    end
+
+    test "sets :invitation_accepted_at when is invited user" do
+      changeset = InvitationUser.user_identity_changeset(%InvitationUser{}, @user_identity, %{}, %{email: "test@example.com"})
+      refute changeset.changes[:invitation_accepted_at]
+
+      changeset = InvitationUser.user_identity_changeset(%InvitationUser{invitation_token: "token", invitation_accepted_at: DateTime.utc_now()}, @user_identity, %{}, %{email: "test@example.com"})
+      refute changeset.changes[:invitation_accepted_at]
+
+      changeset = InvitationUser.user_identity_changeset(%InvitationUser{invitation_token: "token"}, @user_identity, %{}, %{email: "test@example.com"})
+      assert changeset.changes[:invitation_accepted_at]
     end
   end
 

--- a/test/pow_assent/phoenix/views/view_helpers_test.exs
+++ b/test/pow_assent/phoenix/views/view_helpers_test.exs
@@ -35,4 +35,11 @@ defmodule PowAssent.ViewHelpersTest do
     [safe: iodata] = ViewHelpers.provider_links(conn)
     assert {:safe, iodata} == Link.link("Remove Test provider authentication", to: "/auth/test_provider", method: "delete")
   end
+
+  test "provider_links/1 with invited_user", %{conn: conn} do
+    conn = PowInvitation.Plug.assign_invited_user(conn, %PowAssent.Test.Invitation.Users.User{invitation_token: "token"})
+
+    [safe: iodata] = ViewHelpers.provider_links(conn)
+    assert {:safe, iodata} == Link.link("Sign in with Test provider", to: "/auth/test_provider/new?invitation_token=token")
+  end
 end

--- a/test/support/extensions/invitation/phoenix/endpoint.ex
+++ b/test/support/extensions/invitation/phoenix/endpoint.ex
@@ -1,0 +1,33 @@
+defmodule PowAssent.Test.Invitation.Phoenix.Endpoint do
+  @moduledoc false
+  use Phoenix.Endpoint, otp_app: :pow_assent
+
+  plug Plug.RequestId
+  plug Plug.Logger
+
+  plug Plug.Parsers,
+    parsers: [:urlencoded, :multipart, :json],
+    pass: ["*/*"],
+    json_decoder: Phoenix.json_library()
+
+  plug Plug.MethodOverride
+  plug Plug.Head
+
+  plug Plug.Session,
+    store: :cookie,
+    key: "_binaryid_key",
+    signing_salt: "secret"
+
+  plug Pow.Plug.Session,
+    user: PowAssent.Test.Invitation.Users.User,
+    routes_backend: PowAssent.Test.Phoenix.Routes,
+    messages_backend: PowAssent.Test.Phoenix.Messages,
+    mailer_backend: PowAssent.Test.Phoenix.MailerMock,
+    repo: PowAssent.Test.Invitation.RepoMock,
+    otp_app: :pow_assent,
+    pow_assent: [
+      user_identities_context: PowAssent.Test.UserIdentitiesMock
+    ]
+
+  plug PowAssent.Test.Phoenix.Router
+end

--- a/test/support/extensions/invitation/repo_mock.ex
+++ b/test/support/extensions/invitation/repo_mock.ex
@@ -1,0 +1,9 @@
+defmodule PowAssent.Test.Invitation.RepoMock do
+  @moduledoc false
+
+  alias PowAssent.Test.Invitation.Users.User
+
+  @user %User{id: 1, email: "test@example.com"}
+
+  def get_by(User, [invitation_token: "token"]), do: %{@user | invitation_token: "token"}
+end

--- a/test/support/extensions/invitation/user.ex
+++ b/test/support/extensions/invitation/user.ex
@@ -1,0 +1,19 @@
+defmodule PowAssent.Test.Invitation.Users.User do
+  @moduledoc false
+  use Ecto.Schema
+  use Pow.Ecto.Schema
+  use Pow.Extension.Ecto.Schema,
+    extensions: [PowInvitation]
+  use PowAssent.Ecto.Schema
+
+  schema "users" do
+    has_many :user_identities,
+      PowAssent.Test.Invitation.UserIdentities.UserIdentity,
+      on_delete: :delete_all,
+      foreign_key: :user_id
+
+    pow_user_fields()
+
+    timestamps()
+  end
+end

--- a/test/support/extensions/invitation/user_identity.ex
+++ b/test/support/extensions/invitation/user_identity.ex
@@ -1,0 +1,10 @@
+defmodule PowAssent.Test.Invitation.UserIdentities.UserIdentity do
+  @moduledoc false
+  use Ecto.Schema
+  use PowAssent.Ecto.UserIdentities.Schema,
+    user: PowAssent.Test.Invitation.Users.User
+
+  schema "user_identities" do
+    pow_assent_user_identity_fields()
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -19,4 +19,5 @@ Ecto.Adapters.SQL.Sandbox.mode(PowAssent.Test.Ecto.Repo, :manual)
 
 {:ok, _pid} = PowAssent.Test.Phoenix.Endpoint.start_link()
 {:ok, _pid} = PowAssent.Test.EmailConfirmation.Phoenix.Endpoint.start_link()
+{:ok, _pid} = PowAssent.Test.Invitation.Phoenix.Endpoint.start_link()
 {:ok, _pid} = PowAssent.Test.NoRegistration.Phoenix.Endpoint.start_link()


### PR DESCRIPTION
Resolves #36 

When using `oauth_provider_links/1` an `invitation_token` query param will be put in the URL. The controller will detect `invitation_token` query param, and load the user by the token. The changeset will automatically update `:invitation_accepted_at` if it exists.