### PR TITLE
Fix e-mail confirmation bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.2 (TBA)
+
+* Fixed issue where user couldn't be created when PowEmailConfirmation was enabled
+
 ## v0.2.1 (2019-03-16)
 
 * Improve mix task instructions

--- a/lib/pow_assent/ecto/schema.ex
+++ b/lib/pow_assent/ecto/schema.ex
@@ -110,10 +110,15 @@ defmodule PowAssent.Ecto.Schema do
     changeset.data.__struct__.pow_user_id_field_changeset(changeset, user_id_attrs)
   end
 
-  defp maybe_set_confirmed_at(changeset) do
+  defp maybe_set_confirmed_at(%Changeset{data: %user_mod{}} = changeset) do
     case confirmable?(changeset) do
-      true  -> PowEmailConfirmation.Ecto.Schema.confirm_email_changeset(changeset)
-      false -> changeset
+      true  ->
+        confirmed_at = Pow.Ecto.Schema.__timestamp_for__(user_mod, :email_confirmed_at)
+
+        Changeset.change(changeset, email_confirmed_at: confirmed_at)
+
+      false ->
+        changeset
     end
   end
 

--- a/test/pow_assent/ecto/schema_test.exs
+++ b/test/pow_assent/ecto/schema_test.exs
@@ -43,6 +43,12 @@ defmodule PowAssent.Ecto.SchemaTest do
       changeset = User.user_identity_changeset(%User{}, @user_identity, %{email: "test@example.com", name: "John Doe"}, nil)
       assert changeset.valid?
       assert changeset.changes[:name] == "John Doe"
+
+      changeset = UserConfirmEmail.user_identity_changeset(%UserConfirmEmail{}, @user_identity, %{email: "test@example.com", name: "John Doe"}, nil)
+      assert changeset.valid?
+      assert changeset.changes[:email]
+      assert changeset.changes[:email_confirmed_at]
+      assert changeset.changes[:name] == "John Doe"
     end
 
     test "validates unique" do

--- a/test/support/extensions/email_confirmation/user.ex
+++ b/test/support/extensions/email_confirmation/user.ex
@@ -7,8 +7,22 @@ defmodule PowAssent.Test.EmailConfirmation.Users.User do
   use PowAssent.Ecto.Schema
 
   schema "users" do
+    field :name, :string
+
     pow_user_fields()
 
     timestamps()
+  end
+
+  def user_identity_changeset(user_or_changeset, user_identity, attrs, user_id_attrs) do
+    user_or_changeset
+    |> validate_name(attrs)
+    |> pow_assent_user_identity_changeset(user_identity, attrs, user_id_attrs)
+  end
+
+  defp validate_name(changeset, attrs) do
+    changeset
+    |> Ecto.Changeset.cast(attrs, [:name])
+    |> Ecto.Changeset.validate_required([:name])
   end
 end


### PR DESCRIPTION
Resolves #44 and #49.

The issue was that PowAssent relied on the PowEmailConfirmation changeset. Since PowEmailConfirmation will use the existing email from the user struct rather than what's set in the changeset, PowAssent will always get a nil value for email.