### PR TITLE
Fix default_config example in moduledoc

### DIFF
--- a/lib/pow_assent/strategies/oauth/base.ex
+++ b/lib/pow_assent/strategies/oauth/base.ex
@@ -11,7 +11,8 @@ defmodule PowAssent.Strategy.OAuth.Base do
           [
             site: "https://api.example.com",
             authorize_url: "/authorization/new",
-            token_url: "/authorization/token",
+            access_token_url: "/authorization/access_token"
+            request_token_url: "/authorization/request_token",
             user_url: "/authorization.json",
             authorization_params: [scope: "default"]
           ]


### PR DESCRIPTION
`PowAssent.Strategy.OAuth` is using `access_token_url` and `request_token_url` instead of `token_url`.