### PR TITLE
Fix OAuth flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added `:authorization_params` config option to `PowAssent.Strategy.OAuth`
 * Plug and Phoenix controller now handles `:session_params` rather than `:state` for any params that needs to be stored temporarily during authorization
+* Added handling of `oauth_token_secret` to OAuth strategies
 
 ## v0.2.2 (2019-03-25)
 

--- a/test/pow_assent/plug_test.exs
+++ b/test/pow_assent/plug_test.exs
@@ -33,7 +33,7 @@ defmodule PowAssent.PlugTest do
 
     assert url =~ "http://localhost:8888/oauth/authorize?client_id=client_id&redirect_uri=https%3A%2F%2Fexample.com%2F&response_type=code&state="
     assert Map.has_key?(conn.private, :pow_assent_session_params)
-    assert conn.private[:pow_assent_session_params][:state]
+    assert %{state: _state} = conn.private[:pow_assent_session_params]
   end
 
   describe "callback/3" do

--- a/test/pow_assent/strategies/oauth_test.exs
+++ b/test/pow_assent/strategies/oauth_test.exs
@@ -7,7 +7,8 @@ defmodule PowAssent.Strategy.OAuthTest do
     test "returns url", %{config: config, bypass: bypass} do
       expect_oauth_request_token_request(bypass)
 
-      assert {:ok, %{url: url}} = OAuth.authorize_url(config)
+      assert {:ok, %{url: url, session_params: %{oauth_token_secret: oauth_token_secret}}} = OAuth.authorize_url(config)
+      refute is_nil(oauth_token_secret)
       assert url =~ "http://localhost:#{bypass.port}/oauth/authenticate?oauth_token=token"
     end
 
@@ -16,14 +17,14 @@ defmodule PowAssent.Strategy.OAuthTest do
       config = Keyword.put(config, :authorization_params, authorization_params)
       expect_oauth_request_token_request(bypass)
 
-      assert {:ok, %{url: url}} = OAuth.authorize_url(config)
+      assert {:ok, %{url: url, session_params: %{oauth_token_secret: _oauth_token_secret}}} = OAuth.authorize_url(config)
       assert url =~ "http://localhost:#{bypass.port}/oauth/authenticate?another_param=param&oauth_token=token&scope=reading+writing"
     end
 
     test "parses URI query response", %{config: config, bypass: bypass} do
       expect_oauth_request_token_request(bypass, content_type: "text/html", params: URI.encode_query(%{oauth_token: "token", oauth_token_secret: "token_secret"}))
 
-      assert {:ok, %{url: url}} = OAuth.authorize_url(config)
+      assert {:ok, %{url: url, session_params: %{oauth_token_secret: "token_secret"}}} = OAuth.authorize_url(config)
       assert url =~ "http://localhost:#{bypass.port}/oauth/authenticate?oauth_token=token"
     end
 

--- a/test/pow_assent/strategies/twitter_test.exs
+++ b/test/pow_assent/strategies/twitter_test.exs
@@ -100,8 +100,9 @@ defmodule PowAssent.Strategy.TwitterTest do
   test "authorize_url/2", %{config: config, bypass: bypass} do
     expect_oauth_request_token_request(bypass)
 
-    assert {:ok, %{url: url}} = Twitter.authorize_url(config)
+    assert {:ok, %{url: url, session_params: %{oauth_token_secret: oauth_token_secret}}} = Twitter.authorize_url(config)
     assert url =~ "http://localhost:#{bypass.port}/oauth/authenticate?oauth_token=token"
+    refute is_nil(oauth_token_secret)
   end
 
   test "callback/2", %{config: config, callback_params: params, bypass: bypass} do

--- a/test/pow_assent/strategies/twitter_test.exs
+++ b/test/pow_assent/strategies/twitter_test.exs
@@ -101,7 +101,7 @@ defmodule PowAssent.Strategy.TwitterTest do
     expect_oauth_request_token_request(bypass)
 
     assert {:ok, %{url: url, session_params: %{oauth_token_secret: oauth_token_secret}}} = Twitter.authorize_url(config)
-    assert url =~ "http://localhost:#{bypass.port}/oauth/authenticate?oauth_token=token"
+    assert url == "http://localhost:#{bypass.port}/oauth/authenticate?oauth_token=request_token"
     refute is_nil(oauth_token_secret)
   end
 


### PR DESCRIPTION
In OAuth `oauth_token_secret` has to be passed to get an access token.
It works with Twitter, because Twitter doesn't follow spec. At least, that's the information I found.

I will try to wrap it up tomorrow. (I need to add more tests.)