### PR TITLE
Use `session_params` in favor of `state`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.2.3 (TBA)
 
 * Added `:authorization_params` config option to `PowAssent.Strategy.OAuth`
+* Plug and Phoenix controller now handles `:session_params` rather than `:state` for any params that needs to be stored temporarily during authorization
 
 ## v0.2.2 (2019-03-25)
 

--- a/lib/pow_assent/strategies/oauth2/base.ex
+++ b/lib/pow_assent/strategies/oauth2/base.ex
@@ -47,7 +47,7 @@ defmodule PowAssent.Strategy.OAuth2.Base do
     end
   end
 
-  @spec authorize_url(Keyword.t(), module()) :: {:ok, %{state: binary(), url: binary()}}
+  @spec authorize_url(Keyword.t(), module()) :: {:ok, %{session_params: %{state: binary()}, url: binary()}}
   def authorize_url(config, strategy) do
     config
     |> set_config(strategy)

--- a/test/pow_assent/plug_test.exs
+++ b/test/pow_assent/plug_test.exs
@@ -32,7 +32,8 @@ defmodule PowAssent.PlugTest do
     assert {:ok, url, conn} = Plug.authorize_url(conn, "test_provider", "https://example.com/")
 
     assert url =~ "http://localhost:8888/oauth/authorize?client_id=client_id&redirect_uri=https%3A%2F%2Fexample.com%2F&response_type=code&state="
-    assert Map.has_key?(conn.private, :pow_assent_state)
+    assert Map.has_key?(conn.private, :pow_assent_session_params)
+    assert conn.private[:pow_assent_session_params][:state]
   end
 
   describe "callback/3" do

--- a/test/pow_assent/strategies/oauth2_test.exs
+++ b/test/pow_assent/strategies/oauth2_test.exs
@@ -4,7 +4,7 @@ defmodule PowAssent.Strategy.OAuth2Test do
   alias PowAssent.{ConfigurationError, CallbackCSRFError, CallbackError, RequestError, Strategy.OAuth2}
 
   test "authorize_url/2", %{config: config, bypass: bypass} do
-    assert {:ok, %{url: url, state: state}} = OAuth2.authorize_url(config)
+    assert {:ok, %{url: url, session_params: %{state: state}}} = OAuth2.authorize_url(config)
 
     refute is_nil(state)
     assert url =~ "http://localhost:#{bypass.port}/oauth/authorize?client_id=&redirect_uri=&response_type=code&state=#{state}"

--- a/test/support/strategies/oauth2_test_case.ex
+++ b/test/support/strategies/oauth2_test_case.ex
@@ -5,7 +5,7 @@ defmodule PowAssent.Test.OAuth2TestCase do
   setup _tags do
     params = %{"code" => "test", "redirect_uri" => "test", "state" => "test"}
     bypass = Bypass.open()
-    config = [client_secret: "secret", site: "http://localhost:#{bypass.port}", state: "test"]
+    config = [client_secret: "secret", site: "http://localhost:#{bypass.port}", session_params: %{state: "test"}]
 
     {:ok, callback_params: params, config: config, bypass: bypass}
   end


### PR DESCRIPTION
From #55, this changes the flow so strategy just outputs a map with `:session_params` that will be stored in the session rather than `state`.

cc @DiodonHystrix 