### PR TITLE
Refactor provider links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.5 (TBA)
+
+* Added `PowAssent.Phoenix.ViewHelpers.authorization_link/2` and  `PowAssent.Phoenix.ViewHelpers.deauthorization_link/2`
+* Deprecated `PowAssent.Phoenix.ViewHelpers.provider_link/3`
+
 ## v0.2.4 (2019-04-25)
 
 * Fixed so OAuth 2.0 access token request params are in the POST body in accordance with RFC 6749

--- a/README.md
+++ b/README.md
@@ -139,13 +139,13 @@ Otherwise, Pow will raise an error about missing template when the user id field
 You can use `PowAssent.Phoenix.ViewHelpers.provider_links/1` to add provider links to your template files:
 
 ```elixir
-<h1>Registration</h1>
-
 <%= for link <- PowAssent.Phoenix.ViewHelpers.provider_links(@conn),
   do: content_tag(:span, link) %>
 ```
 
-It'll automatically link with "Sign in with PROVIDER" or "Remove PROVIDER authentication" depending on if there's an authenticated user in the connection.
+This can be used in the `WEB_PATH/templates/pow/session/new.html.eex`, `WEB_PATH/templates/pow/registration/new.html.eex` and `WEB_PATH/templates/pow/registration/edit.html.eex` templates. By default "Sign in with PROVIDER" link is shown. A "Remove PROVIDER authentication" link will be shown instead if the user is signed in and the user already have authorized with the provider.
+
+You can also call `PowAssent.Phoenix.ViewHelpers.authorization_link/2` and `PowAssent.Phoenix.ViewHelpers.deauthorization_link/2` to generate a link for a single provider.
 
 ### Setting up a provider
 

--- a/lib/pow_assent/phoenix/views/view_helpers.ex
+++ b/lib/pow_assent/phoenix/views/view_helpers.ex
@@ -8,47 +8,69 @@ defmodule PowAssent.Phoenix.ViewHelpers do
   alias PowAssent.Phoenix.AuthorizationController
 
   @doc """
-  Generates list of provider links.
+  Generates list of authorization links for all configured providers.
+
+  The list of providers will be fetched from the configuration, and
+  `authorization_link/2` will be called on each.
+
+  If a user is assigned to the conn, the authorized providers for a user will
+  be looked up with `PowAssent.Plug.providers_for_current_user/1`.
+  `deauthorization_link/2` will be used for any already authorized providers.
   """
   @spec provider_links(Conn.t()) :: [HTML.safe()]
   def provider_links(conn) do
-    providers_for_user = Plug.providers_for_current_user(conn)
+    available_providers = Plug.available_providers(conn)
+    providers_for_user  = Plug.providers_for_current_user(conn)
 
-    conn
-    |> Plug.available_providers()
-    |> Enum.map(&provider_link(conn, &1, providers_for_user))
+    available_providers
+    |> Enum.map(&{&1, &1 in providers_for_user})
+    |> Enum.map(fn
+      {provider, true} -> deauthorization_link(conn, provider)
+      {provider, false} -> authorization_link(conn, provider)
+    end)
   end
 
   @doc """
-  Generates a provider link.
+  Generates an authorization link for a provider.
 
-  If the user is signed in, and has a provider, it'll link to removal of the
-  provider authorization.
+  The link is used to sign up or register a user using a provider. If
+  `:invited_user` is assigned to the conn, the invitation token will be passed
+  on through the URL query params.
   """
-  @spec provider_link(Conn.t(), atom(), [atom()]) :: HTML.safe()
-  def provider_link(conn, provider, providers_for_user) do
-    case Enum.member?(providers_for_user, provider) do
-      false -> oauth_signin_link(conn, provider)
-      true  -> oauth_remove_link(conn, provider)
-    end
-  end
+  @spec authorization_link(Conn.t(), atom()) :: HTML.safe()
+  def authorization_link(conn, provider) do
+    query_params = authorization_link_query_params(conn)
 
-  defp oauth_signin_link(%{assigns: %{invited_user: %{invitation_token: token}}} = conn, provider) when not is_nil(token) do
-    do_oauth_signin_link(conn, provider, invitation_token: token)
-  end
-  defp oauth_signin_link(conn, provider), do: do_oauth_signin_link(conn, provider)
-
-  defp do_oauth_signin_link(conn, provider, query_params \\[]) do
     msg  = AuthorizationController.extension_messages(conn).login_with_provider(%{conn | params: %{"provider" => provider}})
     path = AuthorizationController.routes(conn).path_for(conn, AuthorizationController, :new, [provider], query_params)
 
     Link.link(msg, to: path)
   end
 
-  defp oauth_remove_link(conn, provider) do
+  defp authorization_link_query_params(%{assigns: %{invited_user: %{invitation_token: token}}}), do: [invitation_token: token]
+  defp authorization_link_query_params(_conn), do: []
+
+  @doc """
+  Generates a provider deauthorization link.
+
+  The link is used to remove authorization with the provider.
+  """
+  @spec deauthorization_link(Conn.t(), atom()) :: HTML.safe()
+  def deauthorization_link(conn, provider) do
     msg  = AuthorizationController.extension_messages(conn).remove_provider_authentication(%{conn | params: %{"provider" => provider}})
     path = AuthorizationController.routes(conn).path_for(conn, AuthorizationController, :delete, [provider])
 
     Link.link(msg, to: path, method: :delete)
+  end
+
+  # TODO: Remove by 0.3.0
+  @doc false
+  @deprecated "Use `authorization_link/2` and `deauthorization_link/2`"
+  @spec provider_link(Conn.t(), atom(), [atom()]) :: HTML.safe()
+  def provider_link(conn, provider, providers_for_user) do
+    case Enum.member?(providers_for_user, provider) do
+      false -> authorization_link(conn, provider)
+      true  -> deauthorization_link(conn, provider)
+    end
   end
 end


### PR DESCRIPTION
Resolves #64 

Now the authorization links are explicit so you call either `authorization_link/2` or `deauthorization_link/2` to link or remove a provider authorization. The docs has been improved to explain how they work.