### PR TITLE
Use `Pow.Plug.get_plug/1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   * `PowAssent.Ecto.UserIdentities.Context.upsert/3`
   * `PowAssent.Ecto.UserIdentities.Context.create_user/4`
 * Fixed bug where invited user was not signed in after succesful authorization
+* Use `Pow.Plug.get_plug/1` instead of pulling `:mod` from the config
 
 ## v0.3.0 (2019-05-19)
 

--- a/test/pow_assent/plug_test.exs
+++ b/test/pow_assent/plug_test.exs
@@ -9,7 +9,7 @@ defmodule PowAssent.PlugTest do
   import PowAssent.Test.TestProvider, only: [expect_oauth2_flow: 1, put_oauth2_env: 1]
 
   @default_config [
-    mod: Pow.Plug.Session,
+    plug: Pow.Plug.Session,
     user: User,
     otp_app: :pow_assent,
     pow_assent: [


### PR DESCRIPTION
With https://github.com/danschultzer/pow/pull/207 PowAssent should now use `Pow.Plug.get_plug/1`. This is a draft until Pow `1.0.9` has been released