### PR TITLE
Handle integer `uid` values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,17 @@
 
 ## v0.3.1 (TBA)
 
-* Fixed bug where invited user was not signed in after succesful authorization
 * User identities are now upserted on authorization so additional params can be updated on authorization request. Following methods has been deprecated:
-  * `PowAssent.Ecto.UserIdentities.Context.create/2` in favor of `PowAssent.Ecto.UserIdentities.Context.upsert/2`
+  * `PowAssent.Ecto.UserIdentities.Context.create/3` in favor of `PowAssent.Ecto.UserIdentities.Context.upsert/3`
   * `MyApp.UserIdentities.create/2` in favor of `MyApp.UserIdentities.upsert/2`
   * `MyApp.UserIdentities.pow_assent_create/2` in favor of `MyApp.UserIdentities.upsert/2`
   * `PowAssent.Operations.create/3` in favor of `PowAssent.Operations.upsert/3`
   * `PowAssent.Plug.create_identity/2` in favor of `PowAssent.Plug.upsert_identity/2`
+* Fixed so `uid` can be an integer value in `PowAssent.Ecto.UserIdentities.Context`. Strategies are no longer expected to convert the `uid` value to binary. The following methods will accepts integer `uid`:
+  * `PowAssent.Ecto.UserIdentities.Context.get_user_by_provider_uid/3`
+  * `PowAssent.Ecto.UserIdentities.Context.upsert/3`
+  * `PowAssent.Ecto.UserIdentities.Context.create_user/4`
+* Fixed bug where invited user was not signed in after succesful authorization
 
 ## v0.3.0 (2019-05-19)
 

--- a/lib/pow_assent/ecto/user_identities/context.ex
+++ b/lib/pow_assent/ecto/user_identities/context.ex
@@ -114,7 +114,9 @@ defmodule PowAssent.Ecto.UserIdentities.Context do
 
   User schema module and repo module will be fetched from the config.
   """
-  @spec get_user_by_provider_uid(binary(), binary(), Config.t()) :: user() | nil
+  @spec get_user_by_provider_uid(binary(), binary() | integer(), Config.t()) :: user() | nil
+  def get_user_by_provider_uid(provider, uid, config) when is_integer(uid),
+    do: get_user_by_provider_uid(provider, Integer.to_string(uid), config)
   def get_user_by_provider_uid(provider, uid, config) do
     config
     |> user_identity_schema_mod()
@@ -164,6 +166,8 @@ defmodule PowAssent.Ecto.UserIdentities.Context do
     |> :maps.from_list()
   end
 
+  defp convert_param({:uid, value}), do: convert_param({"uid", value})
+  defp convert_param({"uid", value}) when is_integer(value), do: convert_param({"uid", Integer.to_string(value)})
   defp convert_param({key, value}) when is_atom(key), do: {Atom.to_string(key), value}
   defp convert_param({key, value}) when is_binary(key), do: {key, value}
 

--- a/lib/pow_assent/strategies/basecamp.ex
+++ b/lib/pow_assent/strategies/basecamp.ex
@@ -29,7 +29,7 @@ defmodule PowAssent.Strategy.Basecamp do
   @spec normalize(Keyword.t(), map()) :: {:ok, map()}
   def normalize(_config, user) do
     {:ok, %{
-      "uid"        => Integer.to_string(user["identity"]["id"]),
+      "uid"        => user["identity"]["id"],
       "name"       => "#{user["identity"]["first_name"]} #{user["identity"]["last_name"]}",
       "first_name" => user["identity"]["first_name"],
       "last_name"  => user["identity"]["last_name"],

--- a/lib/pow_assent/strategies/github.ex
+++ b/lib/pow_assent/strategies/github.ex
@@ -32,7 +32,7 @@ defmodule PowAssent.Strategy.Github do
   @spec normalize(Keyword.t(), map()) :: {:ok, map()} | {:error, term()}
   def normalize(_config, user) do
     {:ok, %{
-      "uid"      => Integer.to_string(user["id"]),
+      "uid"      => user["id"],
       "nickname" => user["login"],
       "email"    => user["email"],
       "name"     => user["name"],

--- a/lib/pow_assent/strategies/twitter.ex
+++ b/lib/pow_assent/strategies/twitter.ex
@@ -26,7 +26,7 @@ defmodule PowAssent.Strategy.Twitter do
   @spec normalize(Keyword.t(), map()) :: {:ok, map()}
   def normalize(_config, user) do
     {:ok, %{
-      "uid"         => Integer.to_string(user["id"]),
+      "uid"         => user["id"],
       "nickname"    => user["screen_name"],
       "email"       => user["email"],
       "location"    => user["location"],

--- a/test/pow_assent/strategies/basecamp_test.exs
+++ b/test/pow_assent/strategies/basecamp_test.exs
@@ -42,7 +42,7 @@ defmodule PowAssent.Strategy.BasecampTest do
     "first_name" => "Jason",
     "last_name" => "Fried",
     "accounts" => @accounts_response,
-    "uid" => "9999999"
+    "uid" => 9_999_999
   }
 
   test "authorize_url/2", %{config: config} do

--- a/test/pow_assent/strategies/github_test.exs
+++ b/test/pow_assent/strategies/github_test.exs
@@ -48,7 +48,7 @@ defmodule PowAssent.Strategy.GithubTest do
     "image" => "https://github.com/images/error/octocat_happy.gif",
     "name" => "monalisa octocat",
     "nickname" => "octocat",
-    "uid" => "1",
+    "uid" => 1,
     "urls" => %{"Blog" => "https://github.com/blog", "GitHub" => "https://github.com/octocat"}
   }
 

--- a/test/pow_assent/strategies/twitter_test.exs
+++ b/test/pow_assent/strategies/twitter_test.exs
@@ -117,7 +117,7 @@ defmodule PowAssent.Strategy.TwitterTest do
       "location" => "San Francisco",
       "name" => "Sean Cook",
       "nickname" => "theSeanCook",
-      "uid" => "38895958",
+      "uid" => 38_895_958,
       "urls" => %{"Twitter" => "https://twitter.com/theSeanCook"}
     }
   end


### PR DESCRIPTION
Now context methods will convert integer `uid` values, leaving less up to the strategy's normalize method. It didn't really make sense to have a hard requirement for binary value, since many services uses integer value for their user id.