### PR TITLE
Support pulling config values from System.get_env() at runtime

### DIFF
--- a/lib/pow_assent/config.ex
+++ b/lib/pow_assent/config.ex
@@ -17,9 +17,13 @@ defmodule PowAssent.Config do
   """
   @spec get(t(), atom(), any()) :: any()
   def get(config, key, default \\ nil) do
-    case Keyword.get(config, key, :not_found) do
+    result = case Keyword.get(config, key, :not_found) do
       :not_found -> get_env_config(config, key, default)
       value      -> value
+    end
+    case result do
+      {:system, sys_key} -> System.get_env(sys_key)
+      value -> value
     end
   end
 

--- a/test/pow_assent/config_test.exs
+++ b/test/pow_assent/config_test.exs
@@ -10,5 +10,8 @@ defmodule PowAssent.ConfigTest do
 
     Application.put_env(:test, :pow_assent, key: 2)
     assert Config.get([otp_app: :test], :key) == 2
+
+    System.put_env("KEY", "3")
+    assert Config.get([key: {:system, "KEY"}], :key) == "3"
   end
 end


### PR DESCRIPTION
The standard approach here is to use `{:system, "KEY_NAME"}` as the configured value, then have the library involved call `System.get_env()` with a variable as its argument, rather than a string or atom, so that it gets compiled as a runtime lookup rather than getting optimized into the build system's value at compile time.
