### PR TITLE
Fix broken deauthorization links. Use href instead of navigate.

### DIFF
--- a/lib/pow_assent/phoenix/html/core_components.ex
+++ b/lib/pow_assent/phoenix/html/core_components.ex
@@ -2,161 +2,192 @@
 # Credo will complain about unless statement but we want this first
 # credo:disable-for-next-line
 unless Pow.dependency_vsn_match?(:phoenix, "< 1.7.0") do
-defmodule PowAssent.Phoenix.HTML.CoreComponents do
-  @moduledoc false
-  use Phoenix.Component
+  defmodule PowAssent.Phoenix.HTML.CoreComponents do
+    @moduledoc false
+    use Phoenix.Component
 
-  alias PowAssent.{Phoenix.AuthorizationController, Plug}
+    alias PowAssent.{Phoenix.AuthorizationController, Plug}
 
-  @doc """
-  Renders a list of authorization links for all configured providers.
+    @doc """
+    Renders a list of authorization links for all configured providers.
 
-  The list of providers will be fetched from the PowAssent configuration, and
-  `authorization_link/1` will be called on each.
+    The list of providers will be fetched from the PowAssent configuration, and
+    `authorization_link/1` will be called on each.
 
-  If a user is assigned to the conn, the authorized providers for a user will
-  be looked up with `PowAssent.Plug.providers_for_current_user/1`.
-  `deauthorization_link/1` will be used for any already authorized providers.
+    If a user is assigned to the conn, the authorized providers for a user will
+    be looked up with `PowAssent.Plug.providers_for_current_user/1`.
+    `deauthorization_link/1` will be used for any already authorized providers.
 
-  ## Examples
+    ## Examples
 
-      <.provider_links conn={@conn} />
+        <.provider_links conn={@conn} />
 
-      <.provider_links conn={@conn}>
-        <:authorization_link class="text-green-500">
-          Sign in with <%= @provider %>
-        <:/authorization_link>
+        <.provider_links conn={@conn}>
+          <:authorization_link class="text-green-500">
+            Sign in with <%= @provider %>
+          <:/authorization_link>
 
-        <:deauthorization_link class="text-red-500">
-          Remove <%= @provider %> authentication
-        <:/deauthorization_link>
-      </.provider_links>
-  """
-  attr :conn, :any, required: true, doc: "the conn"
-
-  slot :authorization_link, doc: "attributes and inner content for the authorization link" do
-    attr :class, :string, doc: "Additional classes added to the `.link` tag"
-  end
-
-  slot :deauthorization_link, doc: "attributes and inner content for the deuathorization link" do
-    attr :class, :string, doc: "Additional classes added to the `.link` tag"
-  end
-
-  def provider_links(assigns) do
-    providers = Plug.available_providers(assigns.conn)
-    providers_for_user = Plug.providers_for_current_user(assigns.conn)
-
-    assigns =
-      assign(
-        assigns,
-        class: %{
-          authorization: (for %{class: class} <- assigns.authorization_link, do: class),
-          deauthorization: (for %{class: class} <- assigns.deauthorization_link, do: class)
-        },
-        label: %{
-          authorization: Enum.reject(assigns.authorization_link, &is_nil(&1.inner_block)),
-          deauthorization: Enum.reject(assigns.deauthorization_link, &is_nil(&1.inner_block))
-        },
-        providers: providers,
-        providers_for_user: providers_for_user
-      )
-
-    ~H"""
-    <%= for provider <- @providers do %><.authorization_link
-        :if={provider not in @providers_for_user}
-        conn={@conn}
-        provider={provider}
-        {@class.authorization != [] && [class: @class.authorization] || []}
-      >
-      <%= @label.authorization != [] && render_slot(@label.authorization, provider) || sign_in_with_provider_label(@conn, provider) %>
-    </.authorization_link><.deauthorization_link
-        :if={provider in @providers_for_user}
-        conn={@conn}
-        provider={provider}
-        {@class.deauthorization != [] && [class: @class.deauthorization] || []}
-     >
-      <%= @label.deauthorization != [] && render_slot(@label.deauthorization, provider) || remove_provider_authentication_label(@conn, provider) %>
-    </.deauthorization_link><% end %>
+          <:deauthorization_link class="text-red-500">
+            Remove <%= @provider %> authentication
+          <:/deauthorization_link>
+        </.provider_links>
     """
-  end
+    attr(:conn, :any, required: true, doc: "the conn")
 
-  defp sign_in_with_provider_label(conn, provider) do
-    AuthorizationController.extension_messages(conn).login_with_provider(%{conn | params: %{"provider" => provider}})
-  end
+    slot :authorization_link, doc: "attributes and inner content for the authorization link" do
+      attr(:class, :string, doc: "Additional classes added to the `.link` tag")
+    end
 
-  defp remove_provider_authentication_label(conn, provider) do
-    AuthorizationController.extension_messages(conn).remove_provider_authentication(%{conn | params: %{"provider" => provider}})
-  end
+    slot :deauthorization_link, doc: "attributes and inner content for the deuathorization link" do
+      attr(:class, :string, doc: "Additional classes added to the `.link` tag")
+    end
 
-  @doc """
-  Renders an authorization link for a provider.
+    def provider_links(assigns) do
+      providers = Plug.available_providers(assigns.conn)
+      providers_for_user = Plug.providers_for_current_user(assigns.conn)
 
-  The link is used to sign up or register a user using a provider. If
-  `:invited_user` is assigned to the conn, the invitation token will be passed
-  on through the URL query params.
+      assigns =
+        assign(
+          assigns,
+          class: %{
+            authorization: for(%{class: class} <- assigns.authorization_link, do: class),
+            deauthorization: for(%{class: class} <- assigns.deauthorization_link, do: class)
+          },
+          label: %{
+            authorization: Enum.reject(assigns.authorization_link, &is_nil(&1.inner_block)),
+            deauthorization: Enum.reject(assigns.deauthorization_link, &is_nil(&1.inner_block))
+          },
+          providers: providers,
+          providers_for_user: providers_for_user
+        )
 
-  ## Examples
+      ~H"""
+      <%= for provider <- @providers do %><.authorization_link
+          :if={provider not in @providers_for_user}
+          conn={@conn}
+          provider={provider}
+          {@class.authorization != [] && [class: @class.authorization] || []}
+        >
+        <%= @label.authorization != [] && render_slot(@label.authorization, provider) || sign_in_with_provider_label(@conn, provider) %>
+      </.authorization_link><.deauthorization_link
+          :if={provider in @providers_for_user}
+          conn={@conn}
+          provider={provider}
+          {@class.deauthorization != [] && [class: @class.deauthorization] || []}
+       >
+        <%= @label.deauthorization != [] && render_slot(@label.deauthorization, provider) || remove_provider_authentication_label(@conn, provider) %>
+      </.deauthorization_link><% end %>
+      """
+    end
 
-      <.authorization_link conn={@conn} provider="github" />
+    defp sign_in_with_provider_label(conn, provider) do
+      AuthorizationController.extension_messages(conn).login_with_provider(%{
+        conn
+        | params: %{"provider" => provider}
+      })
+    end
 
-      <.authorization_link conn={@conn} provider="github">Sign in with Github</.authorization_link>
-  """
-  attr :conn, :any, required: true, doc: "the conn"
-  attr :provider, :any, required: true, doc: "the provider"
+    defp remove_provider_authentication_label(conn, provider) do
+      AuthorizationController.extension_messages(conn).remove_provider_authentication(%{
+        conn
+        | params: %{"provider" => provider}
+      })
+    end
 
-  attr :rest,
-    :global,
-    include: ~w(csrf_token download hreflang referrerpolicy rel target type),
-    doc: "
+    @doc """
+    Renders an authorization link for a provider.
+
+    The link is used to sign up or register a user using a provider. If
+    `:invited_user` is assigned to the conn, the invitation token will be passed
+    on through the URL query params.
+
+    ## Examples
+
+        <.authorization_link conn={@conn} provider="github" />
+
+        <.authorization_link conn={@conn} provider="github">Sign in with Github</.authorization_link>
+    """
+    attr(:conn, :any, required: true, doc: "the conn")
+    attr(:provider, :any, required: true, doc: "the provider")
+
+    attr(
+      :rest,
+      :global,
+      include: ~w(csrf_token download hreflang referrerpolicy rel target type),
+      doc: "
     Additional attributes added to the `.link` tag.
     "
+    )
 
-  slot :inner_block
+    slot(:inner_block)
 
-  def authorization_link(assigns) do
-    query_params = invitation_token_query_params(assigns.conn) ++ request_path_query_params(assigns.conn)
-    path = AuthorizationController.routes(assigns.conn).path_for(assigns.conn, AuthorizationController, :new, [assigns.provider], query_params)
-    assigns = assign(assigns, navigate: path)
+    def authorization_link(assigns) do
+      query_params =
+        invitation_token_query_params(assigns.conn) ++ request_path_query_params(assigns.conn)
 
-    ~H"""
-    <.link navigate={@navigate} {@rest}><%= render_slot(@inner_block) || sign_in_with_provider_label(@conn, @provider) %></.link>
+      path =
+        AuthorizationController.routes(assigns.conn).path_for(
+          assigns.conn,
+          AuthorizationController,
+          :new,
+          [assigns.provider],
+          query_params
+        )
+
+      assigns = assign(assigns, navigate: path)
+
+      ~H"""
+      <.link navigate={@navigate} {@rest}><%= render_slot(@inner_block) || sign_in_with_provider_label(@conn, @provider) %></.link>
+      """
+    end
+
+    defp invitation_token_query_params(%{assigns: %{invited_user: %{invitation_token: token}}}),
+      do: [invitation_token: token]
+
+    defp invitation_token_query_params(_conn), do: []
+
+    defp request_path_query_params(%{assigns: %{request_path: request_path}}),
+      do: [request_path: request_path]
+
+    defp request_path_query_params(_conn), do: []
+
+    @doc """
+    Renders a deauthorization link for a provider.
+
+    The link is used to remove authorization with the provider.
+
+    ## Examples
+
+        <.deauthorization_link conn={@conn} provider="github">
+
+        <.deauthorization_link conn={@conn} provider="github">Remove Github authentication</.deauthorization_link>
     """
+    attr(:conn, :any, required: true, doc: "the conn")
+    attr(:provider, :any, required: true, doc: "the provider")
+
+    attr(
+      :rest,
+      :global,
+      include: ~w(csrf_token download hreflang referrerpolicy rel target type),
+      doc: "Additional attributes added to the `.link` tag."
+    )
+
+    slot(:inner_block)
+
+    def deauthorization_link(assigns) do
+      path =
+        AuthorizationController.routes(assigns.conn).path_for(
+          assigns.conn,
+          AuthorizationController,
+          :delete,
+          [assigns.provider]
+        )
+
+      assigns = assign(assigns, navigate: path)
+
+      ~H"""
+      <.link href={@navigate} method="delete" {@rest}><%= render_slot(@inner_block) || remove_provider_authentication_label(@conn, @provider) %></.link>
+      """
+    end
   end
-
-  defp invitation_token_query_params(%{assigns: %{invited_user: %{invitation_token: token}}}), do: [invitation_token: token]
-  defp invitation_token_query_params(_conn), do: []
-
-  defp request_path_query_params(%{assigns: %{request_path: request_path}}), do: [request_path: request_path]
-  defp request_path_query_params(_conn), do: []
-
-  @doc """
-  Renders a deauthorization link for a provider.
-
-  The link is used to remove authorization with the provider.
-
-  ## Examples
-
-      <.deauthorization_link conn={@conn} provider="github">
-
-      <.deauthorization_link conn={@conn} provider="github">Remove Github authentication</.deauthorization_link>
-  """
-  attr :conn, :any, required: true, doc: "the conn"
-  attr :provider, :any, required: true, doc: "the provider"
-
-  attr :rest,
-    :global,
-    include: ~w(csrf_token download hreflang referrerpolicy rel target type),
-    doc: "Additional attributes added to the `.link` tag."
-
-  slot :inner_block
-
-  def deauthorization_link(assigns) do
-    path = AuthorizationController.routes(assigns.conn).path_for(assigns.conn, AuthorizationController, :delete, [assigns.provider])
-    assigns = assign(assigns, navigate: path)
-
-    ~H"""
-    <.link navigate={@navigate} method="delete" {@rest}><%= render_slot(@inner_block) || remove_provider_authentication_label(@conn, @provider) %></.link>
-    """
-  end
-end
 end

--- a/lib/pow_assent/user_identities/user_identity.ex
+++ b/lib/pow_assent/user_identities/user_identity.ex
@@ -1,4 +1,7 @@
 defmodule PowAssent.UserIdentities.UserIdentity do
+  @moduledoc """
+  PowAssent user identity schema.
+  """
   use Ecto.Schema
   use PowAssent.Ecto.UserIdentities.Schema, user: PowAssent.Users.User
 

--- a/lib/pow_assent/user_identities/user_identity.ex
+++ b/lib/pow_assent/user_identities/user_identity.ex
@@ -1,0 +1,10 @@
+defmodule PowAssent.UserIdentities.UserIdentity do
+  use Ecto.Schema
+  use PowAssent.Ecto.UserIdentities.Schema, user: PowAssent.Users.User
+
+  schema "user_identities" do
+    pow_assent_user_identity_fields()
+
+    timestamps()
+  end
+end

--- a/lib/pow_assent/users/user.ex
+++ b/lib/pow_assent/users/user.ex
@@ -1,4 +1,7 @@
 defmodule PowAssent.Users.User do
+  @moduledoc """
+  Pow user schema.
+  """
   use Ecto.Schema
   use Pow.Ecto.Schema
 

--- a/lib/pow_assent/users/user.ex
+++ b/lib/pow_assent/users/user.ex
@@ -1,0 +1,10 @@
+defmodule PowAssent.Users.User do
+  use Ecto.Schema
+  use Pow.Ecto.Schema
+
+  schema "users" do
+    pow_user_fields()
+
+    timestamps()
+  end
+end

--- a/test/pow_assent/phoenix/html/core_components_test.exs
+++ b/test/pow_assent/phoenix/html/core_components_test.exs
@@ -41,7 +41,7 @@ defmodule PowAssent.Phoenix.HTML.CoreComponentsTest do
 
     expected = fn assigns ->
       ~H"""
-      <.link navigate={"/auth/test_provider"} method="delete">
+      <.link href={"/auth/test_provider"} method="delete">
         Remove Test provider authentication
       </.link><.link navigate={"/auth/other_provider/new"}>
         Sign in with Other provider
@@ -50,7 +50,7 @@ defmodule PowAssent.Phoenix.HTML.CoreComponentsTest do
     end
 
     assert render_component(&template.(&1), %{conn: conn}) ==
-      render_component(&expected.(&1))
+             render_component(&expected.(&1))
   end
 
   test "provider_links/1 with slot assigns", %{conn: conn} do
@@ -66,7 +66,7 @@ defmodule PowAssent.Phoenix.HTML.CoreComponentsTest do
 
     expected = fn assigns ->
       ~H"""
-      <.link navigate={"/auth/test_provider"} method="delete" class="deauth">
+      <.link href={"/auth/test_provider"} method="delete" class="deauth">
         Remove Test provider authentication
       </.link><.link navigate={"/auth/other_provider/new"} class="auth">
         Sign in with Other provider
@@ -75,7 +75,7 @@ defmodule PowAssent.Phoenix.HTML.CoreComponentsTest do
     end
 
     assert render_component(&template.(&1), %{conn: conn}) ==
-      render_component(&expected.(&1))
+             render_component(&expected.(&1))
   end
 
   test "provider_links/1 with slot inner block", %{conn: conn} do
@@ -91,7 +91,7 @@ defmodule PowAssent.Phoenix.HTML.CoreComponentsTest do
 
     expected = fn assigns ->
       ~H"""
-      <.link navigate={"/auth/test_provider"} method="delete">
+      <.link href={"/auth/test_provider"} method="delete">
         Deauthorization
       </.link><.link navigate={"/auth/other_provider/new"}>
         Authorization
@@ -100,7 +100,7 @@ defmodule PowAssent.Phoenix.HTML.CoreComponentsTest do
     end
 
     assert render_component(&template.(&1), %{conn: conn}) ==
-      render_component(&expected.(&1))
+             render_component(&expected.(&1))
   end
 
   test "provider_links/1 with request_path", %{conn: conn} do
@@ -114,7 +114,7 @@ defmodule PowAssent.Phoenix.HTML.CoreComponentsTest do
 
     expected = fn assigns ->
       ~H"""
-      <.link navigate={"/auth/test_provider"} method="delete">
+      <.link href={"/auth/test_provider"} method="delete">
         Remove Test provider authentication
       </.link><.link navigate={"/auth/other_provider/new?request_path=%2Fcustom-url"}>
         Sign in with Other provider
@@ -123,11 +123,14 @@ defmodule PowAssent.Phoenix.HTML.CoreComponentsTest do
     end
 
     assert render_component(&template.(&1), %{conn: conn}) ==
-      render_component(&expected.(&1))
+             render_component(&expected.(&1))
   end
 
   test "provider_links/1 with invited_user", %{conn: conn} do
-    conn = Conn.assign(conn, :invited_user, %PowAssent.Test.Invitation.Users.User{invitation_token: "token"})
+    conn =
+      Conn.assign(conn, :invited_user, %PowAssent.Test.Invitation.Users.User{
+        invitation_token: "token"
+      })
 
     template = fn assigns ->
       ~H"""
@@ -137,7 +140,7 @@ defmodule PowAssent.Phoenix.HTML.CoreComponentsTest do
 
     expected = fn assigns ->
       ~H"""
-      <.link navigate={"/auth/test_provider"} method="delete">
+      <.link href={"/auth/test_provider"} method="delete">
         Remove Test provider authentication
       </.link><.link navigate={"/auth/other_provider/new?invitation_token=token"}>
         Sign in with Other provider
@@ -146,7 +149,7 @@ defmodule PowAssent.Phoenix.HTML.CoreComponentsTest do
     end
 
     assert render_component(&template.(&1), %{conn: conn}) ==
-      render_component(&expected.(&1))
+             render_component(&expected.(&1))
   end
 
   test "authorization_link/1 with assigns", %{conn: conn} do
@@ -163,11 +166,11 @@ defmodule PowAssent.Phoenix.HTML.CoreComponentsTest do
     end
 
     assert render_component(&template.(&1), %{conn: conn}) ==
-      render_component(&expected.(&1))
+             render_component(&expected.(&1))
   end
 
   test "authorization_link/1 with inner block", %{conn: conn} do
-   template = fn assigns ->
+    template = fn assigns ->
       ~H"""
       <CoreComponents.authorization_link conn={@conn} provider="my_provider">
         Authorize
@@ -184,7 +187,7 @@ defmodule PowAssent.Phoenix.HTML.CoreComponentsTest do
     end
 
     assert render_component(&template.(&1), %{conn: conn}) ==
-      render_component(&expected.(&1))
+             render_component(&expected.(&1))
   end
 
   test "deauthorization_link/1 with assigns", %{conn: conn} do
@@ -196,16 +199,16 @@ defmodule PowAssent.Phoenix.HTML.CoreComponentsTest do
 
     expected = fn assigns ->
       ~H"""
-      <.link navigate={"/auth/my_provider"} class="example">Remove My provider authentication</.link>
+      <.link href={"/auth/my_provider"} method="delete" class="example">Remove My provider authentication</.link>
       """
     end
 
     assert render_component(&template.(&1), %{conn: conn}) ==
-      render_component(&expected.(&1))
+             render_component(&expected.(&1))
   end
 
   test "deauthorization_link/1 with inner block", %{conn: conn} do
-   template = fn assigns ->
+    template = fn assigns ->
       ~H"""
       <CoreComponents.deauthorization_link conn={@conn} provider="my_provider">
         Deauthorize
@@ -215,13 +218,13 @@ defmodule PowAssent.Phoenix.HTML.CoreComponentsTest do
 
     expected = fn assigns ->
       ~H"""
-      <.link navigate={"/auth/my_provider"}>
+      <.link href={"/auth/my_provider"} method="delete">
         Deauthorize
       </.link>
       """
     end
 
     assert render_component(&template.(&1), %{conn: conn}) ==
-      render_component(&expected.(&1))
+             render_component(&expected.(&1))
   end
 end


### PR DESCRIPTION
From the docs:
> method (:string) - The HTTP method to use with the link. This is intended for usage outside of LiveView and therefore only works with the href={...} attribute. It has no effect on patch and navigate instructions.