### PR TITLE
Support cross-site cookies in sample cookie config

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Cookie options are passed on to `Plug.Conn.html.put_resp_cookie/4` and can be se
 config :my_app, :pow_assent,
     auth_session_cookie_opts: [
       secure: true,
-      extra: "SameSite=Strict"
+      extra: "SameSite=Lax"
     ]
 
     # If you are using the reathorization plug:


### PR DESCRIPTION
💁 Setting the `SameSite` option to `Strict` for cookies created during a cross-site authentication process like OAuth2 can easily cause failures which will be somewhat opaque to diagnose and fix. This change to the sample cookie configuration provides a sane default for `SameSite` which is more closely aligned to [Phoenix's default cookie configuration](https://github.com/phoenixframework/phoenix/blob/v1.7.18/installer/templates/phx_web/endpoint.ex#L11).

See:
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value